### PR TITLE
fixed file open with unicode chars exception UnicodeDecodeError. Words file parsing is now lazy initiated.

### DIFF
--- a/wordsegment.py
+++ b/wordsegment.py
@@ -28,6 +28,7 @@ Original Copyright (c) 2008-2009 by Peter Norvig
 """
 
 import sys
+import codecs
 from os.path import join, dirname, realpath
 from math import log10
 from functools import wraps
@@ -40,7 +41,7 @@ if sys.hexversion < 0x03000000:
 
 def parse_file(filename):
     "Read `filename` and parse tab-separated file of (word, count) pairs."
-    with open(filename) as fptr:
+    with codecs.open(filename, 'r', 'utf-8') as fptr:
         lines = (line.split('\t') for line in fptr)
         return dict((word, float(number)) for word, number in lines)
 

--- a/wordsegment.py
+++ b/wordsegment.py
@@ -46,8 +46,8 @@ def parse_file(filename):
         return dict((word, float(number)) for word, number in lines)
 
 basepath = join(dirname(realpath(__file__)), 'wordsegment_data')
-unigram_counts = parse_file(join(basepath, 'unigrams.txt'))
-bigram_counts = parse_file(join(basepath, 'bigrams.txt'))
+unigram_counts = None
+bigram_counts = None
 
 def divide(text, limit=24):
     """
@@ -61,6 +61,13 @@ TOTAL = 1024908267229.0
 
 def score(word, prev=None):
     "Score a `word` in the context of the previous word, `prev`."
+    global unigram_counts, bigram_counts
+
+    if unigram_counts is None:
+        unigram_counts = parse_file(join(basepath, 'unigrams.txt'))
+
+    if bigram_counts is None:
+        bigram_counts = parse_file(join(basepath, 'bigrams.txt'))
 
     if prev is None:
         if word in unigram_counts:


### PR DESCRIPTION
When installing the library on newer python versions: 3.5.2 on arch linux,
the following exception is thrown:

```python
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    import wordsegment
  File "/wordsegment/wordsegment.py", line 53, in <module>
    bigram_counts = parse_file(join(basepath, 'bigrams.txt'))
  File "/wordsegment/wordsegment.py", line 45, in parse_file
    for line in fptr.readlines():
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1286: ordinal not in range(128)
```

The `readlines` throws an error as it could not read properly some bytes from the bigrams.txt files.

Also added lazy init files parsing, so when importing the module, it would not parse the files unless there will be any access to the segment function.
