### PR TITLE
Correctly merge lowercase and uppercase bigrams

### DIFF
--- a/lowercase_ngrams.py
+++ b/lowercase_ngrams.py
@@ -1,0 +1,30 @@
+"""Merges frequencies of uppercase and lowercase n-grams.
+
+For example, if the input looks like this:
+
+    aa bb   5
+    Aa bb   3
+    Cc dd   2
+    ee ff   1
+
+This tool outputs:
+
+    aa bb   8
+    cc dd   2
+    ee ff   1
+
+"""
+from __future__ import print_function
+
+import sys
+from collections import Counter
+
+if __name__ == '__main__':
+    ngram_frequency = Counter()
+    for line in sys.stdin:
+        ngram, count = line.split('\t')
+        ngram, count = ngram.lower(), int(count)
+        ngram_frequency[ngram] += count
+
+    for ngram, count in sorted(ngram_frequency.items()):
+        print(ngram, count, sep='\t')

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -93,6 +93,10 @@ def test_segment_12():
     ]
     assert segment(''.join(result)) == result
 
+def test_segment_13():
+    result = ['hello', 'world']
+    assert segment(''.join(result)) == result
+
 def test_main():
     main(['tests/test.txt'])
     result = os.linesep.join(('choose spain', 'this is a test')) + os.linesep


### PR DESCRIPTION
Some entries in the wordsegment/bigrams.txt file used to be duplicated.
In particular, each bigrams was lowercased, but since some bigrams had
an uppercase and lowercase appearance, the same bigram appeared in
lowercase twice. The code only uses one of these entries, causing the
frequency of these bigrams to be underestimated.

The attached program lowercase_ngrams.py lowercases its input while
merging the frequencies correctly. The wordsegment/bigrams.txt file is
updated using this program. The wordsegment/unigrams.txt file did not
have this issue, so it was not changed.

A new test was added to tests/test_coverage.py, showing how "helloworld"
is now correctly segmented as "hello world". Past iterations would
segment this as "helloworld" because the frequency of the bigram was
underestimated.