### PR TITLE
Moved the metadata out of `setup.py` into `setup.cfg`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=44", "wheel", "read_version"]
+build-backend = "setuptools.build_meta"
+
+[tool.read_version]
+version = "wordsegment.__init__:__version__"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = wordsegment
+author = Grant Jenks
+author_email = contact@grantjenks.com
+license = Apache 2.0
+description = English word segmentation.
+url = http://www.grantjenks.com/docs/wordsegment/
+long_description = file: README.rst
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.2
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+
+[options]
+include_package_data = True
+tests_require = tox
+packages = wordsegment

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
 
-import wordsegment
-
 class Tox(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -15,36 +13,6 @@ class Tox(TestCommand):
         errno = tox.cmdline(self.test_args)
         sys.exit(errno)
 
-with io.open('README.rst', encoding='UTF-8') as reader:
-    readme = reader.read()
-
 setup(
-    name='wordsegment',
-    version=wordsegment.__version__,
-    description='English word segmentation.',
-    long_description=readme,
-    author='Grant Jenks',
-    author_email='contact@grantjenks.com',
-    url='http://www.grantjenks.com/docs/wordsegment/',
-    packages=['wordsegment'],
-    include_package_data=True,
-    tests_require=['tox'],
     cmdclass={'test': Tox},
-    license='Apache 2.0',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
 )


### PR DESCRIPTION
Added `pyproject.toml`.
Replaced importing the version variable with reading it from the file using `read_version`.
If we drop `python3 ./setup.py test`, then `setup.py` can be removed completely since now (to build one should use `python3 -m build -nwx`).